### PR TITLE
Add tests for mobile menu toggling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rogov",
+  "version": "1.0.0",
+  "description": "Минималистичный сайт-визитка ведущего архитектора в стиле современного архитектурного дизайна.",
+  "main": "script.js",
+  "scripts": {
+    "test": "node --test \"tests/*.js\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -466,3 +466,6 @@ function addHapticFeedback(element) {
 // Apply haptic feedback to interactive elements
 const interactiveElements = document.querySelectorAll('.portfolio-item, .service-card, .nav-link, .btn');
 interactiveElements.forEach(addHapticFeedback); 
+if (typeof module !== "undefined") {
+    module.exports = { toggleMobileMenu, closeMobileMenu };
+}

--- a/tests/script.spec.js
+++ b/tests/script.spec.js
@@ -1,0 +1,86 @@
+const { test, beforeEach, before } = require('node:test');
+const assert = require('assert');
+
+let toggleMobileMenu;
+let closeMobileMenu;
+let navLinks;
+let menuToggle;
+let overlay;
+
+function createElement() {
+  const classes = new Set();
+  return {
+    classList: {
+      add: cls => classes.add(cls),
+      remove: cls => classes.delete(cls),
+      toggle: cls => classes.has(cls) ? classes.delete(cls) : classes.add(cls),
+      contains: cls => classes.has(cls)
+    }
+  };
+}
+
+function setupDOM() {
+  navLinks = createElement();
+  menuToggle = createElement();
+  overlay = createElement();
+
+  global.document = {
+    body: { style: { overflow: '' } },
+    getElementById: id => {
+      if (id === 'nav-links') return navLinks;
+      if (id === 'nav-overlay') return overlay;
+      return null;
+    },
+    querySelector: selector => (selector === '.mobile-menu-toggle' ? menuToggle : null),
+    querySelectorAll: () => ({ forEach: () => {} }),
+    addEventListener: () => {},
+    head: { appendChild: () => {} }
+  };
+
+  global.window = {
+    addEventListener: () => {},
+    requestAnimationFrame: fn => fn(),
+    scrollY: 0
+  };
+
+  global.navigator = {};
+}
+
+before(() => {
+  setupDOM();
+  ({ toggleMobileMenu, closeMobileMenu } = require('../script.js'));
+});
+
+beforeEach(() => {
+  setupDOM();
+});
+
+test('toggleMobileMenu toggles active classes on elements', () => {
+  toggleMobileMenu();
+  assert(navLinks.classList.contains('active'));
+  assert(menuToggle.classList.contains('active'));
+  assert(overlay.classList.contains('active'));
+
+  toggleMobileMenu();
+  assert(!navLinks.classList.contains('active'));
+  assert(!menuToggle.classList.contains('active'));
+  assert(!overlay.classList.contains('active'));
+});
+
+test('toggleMobileMenu toggles body scroll lock', () => {
+  toggleMobileMenu();
+  assert.strictEqual(document.body.style.overflow, 'hidden');
+
+  toggleMobileMenu();
+  assert.strictEqual(document.body.style.overflow, '');
+});
+
+test('closeMobileMenu clears active classes and restores scroll', () => {
+  toggleMobileMenu();
+  closeMobileMenu();
+
+  assert(!navLinks.classList.contains('active'));
+  assert(!menuToggle.classList.contains('active'));
+  assert(!overlay.classList.contains('active'));
+  assert.strictEqual(document.body.style.overflow, '');
+});


### PR DESCRIPTION
## Summary
- add Node.js test runner setup
- cover mobile menu toggle and close behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e6c2fbac8332b86d4ac00051b47f